### PR TITLE
Fix handling of HTTP error

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -112,11 +112,11 @@ func handleError(resp *http.Response, json []byte, err error) error {
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		defer resp.Request.Body.Close()
-		reqBody, _ := ioutil.ReadAll(resp.Request.Body)
+		defer resp.Body.Close()
+		respBody, _ := ioutil.ReadAll(resp.Body)
 		log.Error("NON-OK Status Code for Request")
 		log.Error("URL: " + resp.Request.URL.String())
-		log.Error("BODY: " + string(reqBody))
+		log.Error("BODY: " + string(respBody))
 		log.Error("STATUS: " + resp.Status)
 		return errors.New("NON-OK Status Code Returned From Mailtrap")
 	}


### PR DESCRIPTION
This closes #2. 

The problem there is that the code is trying to read the _request_ body, and at the time of response it's consumed and set to `nil`. Hopefully the error handler is supposed to display the _response_ body, so that's what the fix does.

BTW, hello from the official Mailtrap team! And thank you for your ingenious library!

